### PR TITLE
Allow Packages in GitHub Subfolders and Branches

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,21 +44,27 @@ exports.parse = function(specString) {
       , url = url.replace(/\/$/, '')
       , urlparts = urlmod.parse(url)
       , parts = urlparts.pathname.split('/')
+      , packageName = parts[parts.length - 1]
       ;
-
-    out.name = parts[parts.length - 1];
 
     // is this a github repository?
     if (urlparts.host == 'github.com') {
       // yes, modify url for raw file server
-
       urlparts.host = 'raw.github.com';
-      var branch = 'master';
+      var repoName = parts[2]
+        , branch = 'master'
+        ;
+
+      // is the path a repository root?
+      if(parts.length < 6){
+          // yes, use the repository name for the package name
+          packageName = repoName;
+      }
 
       // does the path contain subfolders (after the repository name)?
       if(parts.length == 3){
         // no, add 'master' branch
-         parts.push(branch);
+        parts.push(branch);
       } else {
         // yes, extract the branch and remove the 'tree' part
         branch = parts[4];
@@ -69,6 +75,7 @@ exports.parse = function(specString) {
       out.version = branch;
     }
 
+    out.name = packageName;
     out.url = urlmod.format(urlparts) + "/";
   }
 

--- a/index.js
+++ b/index.js
@@ -43,22 +43,36 @@ exports.parse = function(specString) {
     var url = specString.replace('/datapackage.json', '')
       , url = url.replace(/\/$/, '')
       , urlparts = urlmod.parse(url)
-      , path = urlparts.pathname
-      , parts = path.split('/')
+      , parts = urlparts.pathname.split('/')
       ;
 
-    out.url = url + '/';
-    out.name = parts.pop()
+    out.name = parts[parts.length - 1];
 
-    var ghNotRaw = '//github.com';
-    if (url.indexOf(ghNotRaw) != -1) {
-      out.url = url.replace(ghNotRaw, '//raw.github.com') + '/master/';
-      out.version = 'master'
+    // is this a github repository?
+    if (urlparts.host == 'github.com') {
+      // yes, modify url for raw file server
+
+      urlparts.host = 'raw.github.com';
+      var branch = 'master';
+
+      // does the path contain subfolders (after the repository name)?
+      if(parts.length == 3){
+        // no, add 'master' branch
+         parts.push(branch);
+      } else {
+        // yes, extract the branch and remove the 'tree' part
+        branch = parts[4];
+        parts.splice(3, 1);
+      }
+
+      urlparts.pathname = parts.join('/');
+      out.version = branch;
     }
+
+    out.url = urlmod.format(urlparts) + "/";
   }
 
-  out.dataPackageJsonUrl = out.url;
-  out.dataPackageJsonUrl = out.dataPackageJsonUrl.replace(/\/$/, '');
+  out.dataPackageJsonUrl = out.url.replace(/\/$/, '');
   out.dataPackageJsonUrl += '/datapackage.json';
 
   var _tmp = out.name.split('@');
@@ -77,4 +91,3 @@ exports.normalizeDataPackageUrl = function(url) {
   }
   return url;
 };
-

--- a/test/all.js
+++ b/test/all.js
@@ -43,6 +43,14 @@ describe('parse', function() {
     assert.equal(out.name, 'gdp');
   });
 
+  it('github subfolder ok', function() {
+    dpmFolderUrl = 'https://github.com/okfn/dpm/tree/master/test/fixtures/datapackage-example-inline';
+    var out = spec.parse(dpmFolderUrl);
+    assert.equal(out.url, 'https://raw.github.com/okfn/dpm/master/test/fixtures/datapackage-example-inline/');
+    assert.equal(out.dataPackageJsonUrl, 'https://raw.github.com/okfn/dpm/master/test/fixtures/datapackage-example-inline/datapackage.json');
+    assert.equal(out.name, 'datapackage-example-inline');
+  });
+
   it('local path ok', function() {
     gdpUrl = '/tmp/gdp';
     var out = spec.parse(gdpUrl);
@@ -66,4 +74,3 @@ describe('parse', function() {
     assert.equal(out.dataPackageJsonUrl, out.url + 'datapackage.json');
   });
 });
-

--- a/test/all.js
+++ b/test/all.js
@@ -41,6 +41,16 @@ describe('parse', function() {
     assert.equal(out.url, 'https://raw.github.com/datasets/gdp/master/');
     assert.equal(out.dataPackageJsonUrl, 'https://raw.github.com/datasets/gdp/master/datapackage.json');
     assert.equal(out.name, 'gdp');
+    assert.equal(out.version, 'master');
+  });
+
+  it('github branch ok', function() {
+    gdpUrl = 'https://github.com/okfn/dpm/tree/some-branch';
+    var out = spec.parse(gdpUrl);
+    assert.equal(out.url, 'https://raw.github.com/okfn/dpm/some-branch/');
+    assert.equal(out.dataPackageJsonUrl, 'https://raw.github.com/okfn/dpm/some-branch/datapackage.json');
+    assert.equal(out.name, 'dpm');
+    assert.equal(out.version, 'some-branch');
   });
 
   it('github subfolder ok', function() {
@@ -49,6 +59,16 @@ describe('parse', function() {
     assert.equal(out.url, 'https://raw.github.com/okfn/dpm/master/test/fixtures/datapackage-example-inline/');
     assert.equal(out.dataPackageJsonUrl, 'https://raw.github.com/okfn/dpm/master/test/fixtures/datapackage-example-inline/datapackage.json');
     assert.equal(out.name, 'datapackage-example-inline');
+    assert.equal(out.version, 'master');
+  });
+
+  it('github subfolder on branch ok', function() {
+    dpmFolderUrl = 'https://github.com/okfn/dpm/tree/some-branch/test/fixtures/datapackage-example-inline';
+    var out = spec.parse(dpmFolderUrl);
+    assert.equal(out.url, 'https://raw.github.com/okfn/dpm/some-branch/test/fixtures/datapackage-example-inline/');
+    assert.equal(out.dataPackageJsonUrl, 'https://raw.github.com/okfn/dpm/some-branch/test/fixtures/datapackage-example-inline/datapackage.json');
+    assert.equal(out.name, 'datapackage-example-inline');
+    assert.equal(out.version, 'some-branch');
   });
 
   it('local path ok', function() {


### PR DESCRIPTION
This patch correctly handles github urls that point to branches, subfolders and combinations of the two.

This feature more easily allows the scenario implemented in https://github.com/okfn/dpm/pull/51 and whose workaround is found in https://github.com/okfn/dpm/pull/52
