### PR TITLE
Ensure paths are posix

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ exports.parse = function(specString) {
     specString[0] == '/' ||
     (specString.indexOf('http') == -1 && specString[specString.length-1] == '/')
     ) {
-    var path_ = pathmod.resolve(specString)
+    var path_ = pathmod.posix.resolve(specString)
       , path_ = path_.replace('/datapackage.json', '')
       , path_ = path_.replace(/\/$/, '')
       ;

--- a/test/all.js
+++ b/test/all.js
@@ -83,7 +83,7 @@ describe('parse', function() {
 
   it('local relative path ok', function() {
     var gdpUrl = 'tmp/gdp/'
-      , ourpath = pathmod.resolve(gdpUrl) + '/'
+      , ourpath = pathmod.posix.resolve(gdpUrl) + '/'
     ;
 
     var out = spec.parse(gdpUrl);


### PR DESCRIPTION
This fix ensures that path.resolve always treats the URL as POSIX (using '/' instead of '\'), even on windows machines.
