### PR TITLE
Add .gitignore, don't package tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "mocha test"
   },
+  "files": ["index.js"],
   "repository": {
     "type": "git",
     "url": "http://github.com/okfn/datapackage-identifier.git"


### PR DESCRIPTION
With this change:
- node_modules will be excluded from git via .gitignore
- test files will not be published when publishing to npm.
